### PR TITLE
Remove needless node keyring command

### DIFF
--- a/cmd/brew-bootstrap-asdf
+++ b/cmd/brew-bootstrap-asdf
@@ -52,7 +52,6 @@ if [ ! -z "$(grep nodejs .tool-versions)" ]; then
 brew "gpg"
 EOF
 
-  bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring
 fi
 log_step "Installing package versions with asdf..."
 (

--- a/cmd/brew-bootstrap-system
+++ b/cmd/brew-bootstrap-system
@@ -34,7 +34,6 @@ fi
 if [ -z "$(asdf plugin list | grep nodejs)" ]; then
   asdf plugin add nodejs
 fi
-bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring
 echo "OK"
 
 # Switch to zsh (but only if the user is on a standard bash shell)


### PR DESCRIPTION
This is no longer required as of December 2021, as asdf changed their nodejs plugin to not rely on it. See https://github.com/asdf-vm/asdf-nodejs/pull/272

They should now be using node-build, which verifies the signatures internally